### PR TITLE
tune the nat gateway status check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Python_boto3_VPC
-Aim: This project is to create two EC2 instances from a VPC - One is in public subnet (jumping box) and the other is in private subnet(ec2-pri). Also, only ssh from the jumping box to ec2-pri is allowed.
-Language: Python boto3 SDK
-Use: Pull from this repository and run with python 
+
+* Aim: This project is to create two EC2 instances from a VPC - One is in public subnet (bastion box or jumping server) and the other is in private subnet(application server). After ssh to bastion box, then application server, you should be fine to run `yum update` to access internete. Also, only ssh from the jumping box to ec2-pri is allowed.
+
+* Language: Python boto3 SDK
+
+* Use: Pull from this repository and run with python 

--- a/vpc.py
+++ b/vpc.py
@@ -1,5 +1,6 @@
 import time
 import boto3
+import botocore
 
 ec2 = boto3.resource('ec2')
 ec2_client = boto3.client('ec2')
@@ -38,20 +39,16 @@ print(route_table.id)
 # create a nat gateway
 nat_gw = ec2_client.create_nat_gateway(SubnetId=pub_subnet.id,
                                        AllocationId=addr['AllocationId'])
-print('the nat gatway id is: ' + nat_gw['NatGateway']['NatGatewayId'])
 
-#s = True
+nat_gw_id = nat_gw['NatGateway']['NatGatewayId']
 
-#while s:
-#    if (nat_gw['NatGateway']['State']) != 'available':
-#        print(nat_gw['NatGateway']['State'])
-#        time.sleep(20)
-#    else:
-#        print('Nat Gateway is ready')
-#        s = False
+print('the nat gatway id is: ' + nat_gw_id)
 
-time.sleep(300)
-print(nat_gw['NatGateway']['State'])
+try:
+  print('check nat gateway status, wait it to be available")
+  ec2_client.get_waiter('nat_gateway_available').wait(NatGatewayIds=[nat_gw_id])
+except botocore.exceptions.WaiterError as e:
+  print(e)
 
 # create a route table and a private route
 pri_route_table = vpc.create_route_table()
@@ -88,13 +85,10 @@ print(sec_group.id)
 # create a key pair
 keypair = ec2_client.create_key_pair(KeyName='python-keypair')
 
-<<<<<<< HEAD
-=======
 private_key_file = open('python-keypair.pem', "w")
 private_key_file.write(keypair['KeyMaterial'])
 private_key_file.close
 
->>>>>>> 3c053811eaffc755dab5f0f2c729c0217fac9f29
 # create an instance in public subnet
 instance = ec2.create_instances(ImageId='ami-075a72b1992cb0687',
                                 InstanceType='t2.micro',

--- a/vpc.py
+++ b/vpc.py
@@ -45,10 +45,11 @@ nat_gw_id = nat_gw['NatGateway']['NatGatewayId']
 print('the nat gatway id is: ' + nat_gw_id)
 
 try:
-  print('check nat gateway status, wait it to be available")
-  ec2_client.get_waiter('nat_gateway_available').wait(NatGatewayIds=[nat_gw_id])
+    print('check nat gateway status, wait it to be available')
+    ec2_client.get_waiter('nat_gateway_available').wait(
+        NatGatewayIds=[nat_gw_id])
 except botocore.exceptions.WaiterError as e:
-  print(e)
+    print(e)
 
 # create a route table and a private route
 pri_route_table = vpc.create_route_table()


### PR DESCRIPTION
1. use watier to detect the nat gateway status `nat_gateway_available` (https://boto3.amazonaws.com/v1/documentation/api/latest/guide/clients.html)
2. use `try` and `except` to handle the error smooth.
3. update README with better markdown (https://guides.github.com/features/mastering-markdown/)